### PR TITLE
Don't swallow received communication, always return line

### DIFF
--- a/octoprint_calibrationcompanion/__init__.py
+++ b/octoprint_calibrationcompanion/__init__.py
@@ -206,8 +206,8 @@ class calibrationcompanion(octoprint.plugin.SettingsPlugin,
 			currentEsteps = re.findall(r"[-+]?\d*\.\d+|\d+", line)[4]
 			self._settings.set(["current_e_steps"], currentEsteps)
 			self._settings.save()
-		else:
-			return line  # Avoid blocking the communication
+
+		return line  # Avoid blocking the communication
 		"""elif "PID Autotune start" in line:
 			self.iteration = 0
 			self._plugin_manager.send_plugin_message("calibrationcompanion", {"cycleIteration": self.iteration})


### PR DESCRIPTION
Need to always return something here, otherwise the rest of the communication doesn't get the line.

https://docs.octoprint.org/en/master/plugins/hooks.html#octoprint-comm-protocol-gcode-received